### PR TITLE
validacion de relaciones antes de hacer un insert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules/
 .nyc_output/
-coverages/
+coverage/

--- a/.nycrc
+++ b/.nycrc
@@ -1,6 +1,6 @@
 {
   "exclude": [
-    "coverages/",
+    "coverage/",
     "tests/",
     "mocks/",
     ".eslintrc.js",

--- a/lib/api-save-data.js
+++ b/lib/api-save-data.js
@@ -60,7 +60,7 @@ class ApiSaveData extends API {
 				id: savedId
 			});
 		} catch(e) {
-			throw new ApiSaveError(e.message, ApiSaveError.codes.INTERNAL_ERROR);
+			throw new ApiSaveError(e.message, ApiSaveError.codes.INTERNAL_ERROR, e);
 		}
 	}
 

--- a/lib/api-save-error.js
+++ b/lib/api-save-error.js
@@ -12,11 +12,14 @@ class ApiSaveError extends Error {
 
 	}
 
-	constructor(err, code) {
+	constructor(err, code, previousError) {
 		super(err);
 		this.message = err.message || err;
 		this.code = code;
 		this.name = 'ApiSaveError';
+
+		if(previousError)
+			this.previousError = previousError;
 	}
 }
 

--- a/lib/api-save-relationships.js
+++ b/lib/api-save-relationships.js
@@ -36,7 +36,11 @@ class ApiSaveRelationships {
 
 		const relationshipsToSave = this._formatRelationshipsToInsert(relationship, relationshipParameters);
 
+		if(!relationshipsToSave.length)
+			return Promise.resolve();
+
 		const model = this.apiInstance.client ? this.apiInstance.client.getInstance(ModelClass) : new ModelClass();
+
 		return model.multiInsert(relationshipsToSave);
 	}
 

--- a/lib/api-save-relationships.js
+++ b/lib/api-save-relationships.js
@@ -44,12 +44,12 @@ class ApiSaveRelationships {
 		return model.multiInsert(relationshipsToSave);
 	}
 
-	insertAndRemove(relationship, relationshipParameters) {
+	async insertAndRemove(relationship, relationshipParameters) {
 
 		const { modelClass: ModelClass, mainIdentifierField } = relationshipParameters;
 
 		const model = this.apiInstance.client ? this.apiInstance.client.getInstance(ModelClass) : new ModelClass();
-		const currentRelationships = model.get({
+		const currentRelationships = await model.get({
 			[mainIdentifierField]: this.mainId
 		});
 

--- a/lib/api-save-validator.js
+++ b/lib/api-save-validator.js
@@ -36,7 +36,7 @@ class ApiSaveValidator {
 			});
 		} catch(e) {
 			const errorPath = e.path.join('.');
-			throw new ApiSaveError(`${e.message} in ${errorPath}`, ApiSaveError.codes.INVALID_REQUEST_DATA);
+			throw new ApiSaveError(`${e.message} in ${errorPath}`, ApiSaveError.codes.INVALID_REQUEST_DATA, e);
 		}
 	}
 
@@ -44,7 +44,7 @@ class ApiSaveValidator {
 		try {
 			return this._getModelInstance(path.join(process.cwd(), process.env.MS_PATH || '', 'models', this.apiInstance.modelName));
 		} catch(e) {
-			throw new ApiSaveError(e.message, ApiSaveError.codes.INVALID_ENTITY);
+			throw new ApiSaveError(e.message, ApiSaveError.codes.INVALID_ENTITY, e);
 		}
 	}
 


### PR DESCRIPTION
Se valido si no están vacías las relaciones al momento de hacer un insert

ademas se agrego en la clase apiSaveError la posibilidad de enviar un error externo al package 